### PR TITLE
.proto cannot be generated outside current directory

### DIFF
--- a/cmd/oa2proto/oa2proto.go
+++ b/cmd/oa2proto/oa2proto.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/Axili39/oastools/oasmodel"
 	"github.com/Axili39/oastools/protobuf"
@@ -28,7 +29,8 @@ func (i *stringList) Set(value string) error {
 }
 
 func compileProto(protofilename string, directory string) {
-	cmd := exec.Command("protoc", "--go_out="+directory, protofilename)
+	protoPath := filepath.Dir(protofilename)
+	cmd := exec.Command("protoc", "--go_out="+directory, "--proto_path="+protoPath, protofilename)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = os.Stdout

--- a/cmd/oa2proto/version.go
+++ b/cmd/oa2proto/version.go
@@ -1,5 +1,5 @@
 package main
 
 const (
-	version = "v1.0.3"
+	version = "v1.0.4"
 )


### PR DESCRIPTION
protoc assumes --proto_path is the current directory and the .proto file should be there.
If not, we must specify a --proto_path which encompasses this file.